### PR TITLE
Перевод нескольких новых ключей локали для Rails 3

### DIFF
--- a/lib/russian/locale/actionview.yml
+++ b/lib/russian/locale/actionview.yml
@@ -160,3 +160,11 @@ ru:
     select:
       # default value for :prompt => true in FormOptionsHelper
       prompt: "Выберите: "
+
+  helpers:
+    select:
+      prompt: "Выберите: "
+    submit:
+      create: 'Сохранить %{model}'
+      update: 'Обновить %{model}'
+      submit: 'Сохранить %{model}'

--- a/spec/locale_spec.rb
+++ b/spec/locale_spec.rb
@@ -75,6 +75,12 @@ describe Russian, "loading locales" do
     activerecord.errors.template.body
     
     support.select.prompt
+
+    helpers.submit.create
+    helpers.submit.update
+    helpers.submit.submit
+
+    helpers.select.prompt
   ).each do |key| 
     it "should define '#{key}' in actionview translations" do
       lookup(key).should_not be_nil


### PR DESCRIPTION
Ключи "helpers.submit.*":
https://github.com/rails/rails/blob/master/actionpack/lib/action_view/helpers/form_helper.rb#L1265
https://github.com/rails/rails/blob/master/actionpack/lib/action_view/helpers/form_helper.rb#L1275

Ключ "helpers.select.prompt":
https://github.com/rails/rails/blob/master/actionpack/lib/action_view/helpers/form_options_helper.rb#L601
