### PR TITLE
Замена неподдреживаемого psych формата задания массива

### DIFF
--- a/lib/russian/locale/datetime.yml
+++ b/lib/russian/locale/datetime.yml
@@ -32,7 +32,10 @@ ru:
     #
     #
     # Used in date_select and datime_select.
-    order: [ :day, :month, :year ]
+    order: 
+      - :day
+      - :month
+      - :year
 
   time:
     # Форматы времени


### PR DESCRIPTION
datetime.yml использовал несовместимый с psych (новая версия yaml engine в 1.9, по дефолту используемая, если пристутствует, в версиях рельс старше 3.0.4) формат массива
