### PR TITLE
Исправление невалидного для Psych формата YAML.

### DIFF
--- a/lib/russian/locale/datetime.yml
+++ b/lib/russian/locale/datetime.yml
@@ -32,7 +32,11 @@ ru:
     #
     #
     # Used in date_select and datime_select.
-    order: [ :day, :month, :year ]
+    order:
+      - :day
+      - :month
+      - :year
+    
 
   time:
     # Форматы времени


### PR DESCRIPTION
При использовании библиотеки Psych для загрузки YAML-файлов в моем окружении (Ruby 1.9.2 p180, Bundler 1.0.10, ActiveSupport 3.0.5) проявляется ошибка:

<pre>
/Users/oruen/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/psych.rb:150:in `parse': couldn't parse YAML at line 35 column 14 (Psych::SyntaxError)
    from /Users/oruen/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/psych.rb:150:in `parse_stream'
    from /Users/oruen/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/psych.rb:119:in `parse'
    from /Users/oruen/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/psych.rb:106:in `load'
    from /Users/oruen/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/psych.rb:207:in `load_file'
    from /Users/oruen/.rvm/gems/ruby-1.9.2-p180@sfk/gems/i18n-0.5.0/lib/i18n/backend/base.rb:172:in `load_yml'
    from /Users/oruen/.rvm/gems/ruby-1.9.2-p180@sfk/gems/i18n-0.5.0/lib/i18n/backend/base.rb:158:in `load_file'
    from /Users/oruen/.rvm/gems/ruby-1.9.2-p180@sfk/gems/i18n-0.5.0/lib/i18n/backend/base.rb:17:in `block in load_translations'
    from /Users/oruen/.rvm/gems/ruby-1.9.2-p180@sfk/gems/i18n-0.5.0/lib/i18n/backend/base.rb:17:in `each'
    from /Users/oruen/.rvm/gems/ruby-1.9.2-p180@sfk/gems/i18n-0.5.0/lib/i18n/backend/base.rb:17:in `load_translations'
    from /Users/oruen/.rvm/gems/ruby-1.9.2-p180@sfk/gems/i18n-0.5.0/lib/i18n/backend/simple.rb:55:in `init_translations'
    from /Users/oruen/.rvm/gems/ruby-1.9.2-p180@sfk/gems/i18n-0.5.0/lib/i18n/backend/simple.rb:69:in `lookup'
    from /Users/oruen/.rvm/gems/ruby-1.9.2-p180@sfk/gems/russian-0.2.7/lib/russian/backend/advanced.rb:114:in `pluralize'
    from /Users/oruen/.rvm/gems/ruby-1.9.2-p180@sfk/gems/russian-0.2.7/lib/russian.rb:87:in `pluralize'

</pre>

Это та же ошибка, что упоминается в https://rails.lighthouseapp.com/projects/8994/tickets/6354-psych-does-not-handle-symbols-in-yaml-used-in-activesupport

Изменение формата записи массива символов решает проблему.
