### PR TITLE
Исправление некорректного отображения названия месяца в случае использов...

### DIFF
--- a/lib/russian.rb
+++ b/lib/russian.rb
@@ -21,8 +21,8 @@ module Russian
   end
 
   # Regexp machers for context-based russian month names and day names translation
-  LOCALIZE_ABBR_MONTH_NAMES_MATCH = /(%d|%e)(.*)(%b)/
-  LOCALIZE_MONTH_NAMES_MATCH = /(%-?d|%e)(.*)(%B)/
+  LOCALIZE_ABBR_MONTH_NAMES_MATCH = /(%[-\d]?d|%e)(.*)(%b)/
+  LOCALIZE_MONTH_NAMES_MATCH = /(%[-\d]?d|%e)(.*)(%B)/
   LOCALIZE_STANDALONE_ABBR_DAY_NAMES_MATCH = /^%a/
   LOCALIZE_STANDALONE_DAY_NAMES_MATCH = /^%A/
     


### PR DESCRIPTION
...ания ключа %-d или %1d:

Russian::strftime(Time.now-1000000,"%d %b %Y") => "06 мая 2012"
Russian::strftime(Time.now-1000000,"%-d %b %Y") => "6 май 2012"
Russian::strftime(Time.now-1000000,"%1d %b %Y") => "6 май 2012"
