### PR TITLE
Sort locale files list alphabetically

### DIFF
--- a/lib/russian.rb
+++ b/lib/russian.rb
@@ -80,7 +80,7 @@ module Russian
   protected
     # Returns all locale files shipped with library
     def locale_files
-      Dir[File.join(File.dirname(__FILE__), "russian", "locale", "**/*")]
+      Dir[File.join(File.dirname(__FILE__), "russian", "locale", "**/*")].sort
     end
     
     # Converts an array of pluralization variants to a Hash that can be used


### PR DESCRIPTION
See fnando/i18n-js#239 for explanation, investigation and discussion.

In short: list of files with translations should be always the same (including order). `Dir[]` may produce list of file paths with different order on different machines.

For example:  In case of [i18n-js](https://github.com/fnando/i18n-js) gem it need to produce always equal translation data. If it's not equal and Rails Asset Pipeline is used, it will lead to generating assets with different hashsums on different servers and link to asset in generated page and in the web server will be different, and site will become broken.

There is probably no good solution possible on the side of [i18n](https://github.com/svenfuchs/i18n) or [i18n-js](https://github.com/fnando/i18n-js) gems. So every app and every gem should push to `I18n.load_path` sorted list of filenames.

That's it.
