### PR TITLE
Support preceding dashes in date formats

### DIFF
--- a/lib/russian.rb
+++ b/lib/russian.rb
@@ -21,8 +21,8 @@ module Russian
   end
 
   # Regexp machers for context-based russian month names and day names translation
-  LOCALIZE_ABBR_MONTH_NAMES_MATCH = /(%[-\d]?d|%e)(.*)(%b)/
-  LOCALIZE_MONTH_NAMES_MATCH = /(%[-\d]?d|%e)(.*)(%B)/
+  LOCALIZE_ABBR_MONTH_NAMES_MATCH = /(%[-\d]?d|%\-?e)(.*)(%b)/
+  LOCALIZE_MONTH_NAMES_MATCH = /(%[-\d]?d|%\-?e)(.*)(%B)/
   LOCALIZE_STANDALONE_ABBR_DAY_NAMES_MATCH = /^%a/
   LOCALIZE_STANDALONE_DAY_NAMES_MATCH = /^%A/
     


### PR DESCRIPTION
### Problem
The gem does not support date formats without leading zero, i.e. `%-e`.

### Actual behavior

```ruby
I18n.l(Date.new(2018, 11, 9), format: '%-e %B') # => "9 Ноябрь"
```

### Expected behavior
```ruby
I18n.l(Date.new(2018, 11, 9), format: '%-e %B') # => "9 ноября"
```

_Gem versions:_
russian (0.6.0)
i18n (>= 0.5.0)
