### PR TITLE
expanded options in Russian#localize

### DIFF
--- a/lib/russian.rb
+++ b/lib/russian.rb
@@ -44,7 +44,7 @@ module Russian
   
   # See I18n::localize
   def localize(object, options = {})
-    I18n.localize(object, options.merge({ :locale => LOCALE }))
+    I18n.localize(object, **options.merge({ :locale => LOCALE }))
   end
   alias :l :localize
   


### PR DESCRIPTION
Russian.strftime(Time.now, '«%d» %B %Y г.') causes error in ruby 3+:
```gems/i18n-1.12.0/lib/i18n.rb:304:in `localize': wrong number of arguments (given 2, expected 1) (ArgumentError)
gems/russian-0.6.0/lib/russian.rb:50:in `localize'
gems/russian-0.6.0/lib/russian.rb:56:in `strftime'